### PR TITLE
Add case insensitive matching for locale file names

### DIFF
--- a/twitter_cldr.js
+++ b/twitter_cldr.js
@@ -6,7 +6,7 @@ exports.load = function (locale) {
    * Generated programmatically via Ruby:
    *
    * ```rb
-   * Dir.entries('./full').filter{ |x| x.end_with?('.js') && x != 'core.js' }.map{ |x| x.slice(0, x.length - 3) }.sort
+   * Dir.entries('./full').select { |x| x.end_with?('.js') && x != 'core.js' }.map { |x| x[0..-4] }.sort
    * ```
    */
   var localeFileNames = ['af', 'ar', 'be', 'bg', 'bn', 'ca', 'cs', 'cy', 'da', 'de', 'de-CH', 'el', 'en', 'en-150', 'en-AU', 'en-CA', 'en-GB', 'en-IE', 'en-SG', 'en-ZA', 'es', 'es-419', 'es-CO', 'es-MX', 'es-US', 'eu', 'fa', 'fi', 'fil', 'fr', 'fr-BE', 'fr-CA', 'fr-CH', 'ga', 'gl', 'he', 'hi', 'hr', 'hu', 'id', 'is', 'it', 'it-CH', 'ja', 'ko', 'lv', 'msa', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'sk', 'sq', 'sr', 'sv', 'ta', 'th', 'tr', 'uk', 'ur', 'vi', 'zh-cn', 'zh-tw'];

--- a/twitter_cldr.js
+++ b/twitter_cldr.js
@@ -2,8 +2,18 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 exports.load = function (locale) {
-  var TwitterCLDR = require('./full/core');
-  var TwitterCLDRDataBundle = require('./full/' + locale);
-  TwitterCLDR.set_data(TwitterCLDRDataBundle);
-  return TwitterCLDR;
+  /**
+   * Generated programmatically via Ruby:
+   *
+   * ```rb
+   * Dir.entries('./full').filter{ |x| x.end_with?('.js') && x != 'core.js' }.map{ |x| x.slice(0, x.length - 3) }.sort
+   * ```
+   */
+  var localeFileNames = ['af', 'ar', 'be', 'bg', 'bn', 'ca', 'cs', 'cy', 'da', 'de', 'de-CH', 'el', 'en', 'en-150', 'en-AU', 'en-CA', 'en-GB', 'en-IE', 'en-SG', 'en-ZA', 'es', 'es-419', 'es-CO', 'es-MX', 'es-US', 'eu', 'fa', 'fi', 'fil', 'fr', 'fr-BE', 'fr-CA', 'fr-CH', 'ga', 'gl', 'he', 'hi', 'hr', 'hu', 'id', 'is', 'it', 'it-CH', 'ja', 'ko', 'lv', 'msa', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'sk', 'sq', 'sr', 'sv', 'ta', 'th', 'tr', 'uk', 'ur', 'vi', 'zh-cn', 'zh-tw'];
+
+  var localeFileName = localeFileNames.find(function (fileName) {
+    return fileName.toLowerCase() === locale.toLowerCase();
+  });
+
+  return ('./full/' + (localeFileName || locale));
 };


### PR DESCRIPTION
Solves the problem of inconsistent casing in file names, as illustrated by the following minimal example:

```js
import twitterCldr from 'twitter_cldr'

twitterCldr.load('es-MX').Settings.locale() // 'es-MX'
twitterCldr.load('es-mx').Settings.locale() // Uncaught Error: Cannot find module './full/es-mx'
twitterCldr.load('zh-CN').Settings.locale() // Uncaught Error: Cannot find module './full/zh-CN'
twitterCldr.load('zh-cn').Settings.locale() // 'zh'
```

New behavior as follows:

```js
import twitterCldr from 'twitter_cldr'

twitterCldr.load('es-MX').Settings.locale() // 'es-MX'
twitterCldr.load('es-mx').Settings.locale() // 'es-MX'
twitterCldr.load('zh-CN').Settings.locale() // 'zh'
twitterCldr.load('zh-cn').Settings.locale() // 'zh'
twitterCldr.load('no-file-here') // Uncaught Error: Cannot find module './full/no-file-here'
```